### PR TITLE
fix: resolve #2 - swarm automated fix

### DIFF
--- a/lib/legion/extensions/scheduler/runners/emergency_promotion.rb
+++ b/lib/legion/extensions/scheduler/runners/emergency_promotion.rb
@@ -1,0 +1,50 @@
+# frozen_string_literal: true
+
+module Legion
+  module Extensions
+    module Scheduler
+      module Runners
+        module EmergencyPromotion
+          include Legion::Extensions::Helpers::Transport
+          include Legion::Extensions::Helpers::Cache
+          include Legion::Extensions::Helpers::Data
+          include Legion::Extensions::Helpers::Lex
+
+          EMERGENCY_PATTERNS = %w[extinction consent_violation].freeze
+
+          def promote(**opts)
+            event_type = opts[:event_type] || opts['event_type']
+            return unless emergency_event?(event_type)
+
+            current_mode = fetch_current_mode
+            return if current_mode == 'active'
+
+            execute_emergency_promotion(from: current_mode, event_type: event_type)
+          end
+
+          def emergency_event?(event_type)
+            return false unless event_type
+
+            patterns = emergency_patterns
+            patterns.any? { |pattern| event_type.to_s.include?(pattern) }
+          end
+
+          def emergency_patterns
+            return settings.dig(:scheduler, :emergency_patterns) if settings.dig(:scheduler, :emergency_patterns)
+
+            EMERGENCY_PATTERNS
+          end
+
+          def fetch_current_mode
+            Legion::Cache.get('scheduler_operating_mode') || 'active'
+          end
+
+          def execute_emergency_promotion(from:, event_type:)
+            Legion::Cache.set('scheduler_operating_mode', 'active', 3600)
+            Legion::Logging.send(:warn, "Emergency promotion to active from #{from} due to #{event_type}") if defined?(Legion::Logging)
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/legion/extensions/scheduler/runners/mode_scheduler.rb
+++ b/lib/legion/extensions/scheduler/runners/mode_scheduler.rb
@@ -1,0 +1,62 @@
+# frozen_string_literal: true
+
+module Legion
+  module Extensions
+    module Scheduler
+      module Runners
+        module ModeScheduler
+          include Legion::Extensions::Helpers::Transport
+          include Legion::Extensions::Helpers::Cache
+          include Legion::Extensions::Helpers::Data
+          include Legion::Extensions::Helpers::Lex
+
+          MODES = %w[active idle dream maintenance].freeze
+
+          def evaluate_mode(**)
+            schedule = mode_schedule
+            return unless schedule
+
+            current_hour = Time.now.hour
+            new_mode = determine_mode(current_hour, schedule)
+            return unless new_mode
+
+            current_mode = fetch_current_mode
+            return if current_mode == new_mode
+
+            execute_mode_change(from: current_mode, to: new_mode)
+          end
+
+          def mode_schedule
+            return settings.dig(:scheduler, :mode_schedule) if settings.dig(:scheduler, :mode_schedule)
+
+            default_mode_schedule
+          end
+
+          def default_mode_schedule
+            {
+              active:      (8..17).to_a,
+              idle:        (18..21).to_a,
+              dream:       [22, 23, 0, 1, 2, 3, 4, 5],
+              maintenance: [6, 7]
+            }
+          end
+
+          def determine_mode(hour, schedule)
+            schedule.each do |mode, hours|
+              return mode.to_s if hours.include?(hour)
+            end
+            nil
+          end
+
+          def fetch_current_mode
+            Legion::Cache.get('scheduler_operating_mode') || 'active'
+          end
+
+          def execute_mode_change(from:, to:)
+            Legion::Cache.set('scheduler_operating_mode', to, 3600)
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/legion/extensions/scheduler/runners/mode_transition.rb
+++ b/lib/legion/extensions/scheduler/runners/mode_transition.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+module Legion
+  module Extensions
+    module Scheduler
+      module Runners
+        module ModeTransition
+          include Legion::Extensions::Helpers::Transport
+          include Legion::Extensions::Helpers::Cache
+          include Legion::Extensions::Helpers::Data
+          include Legion::Extensions::Helpers::Lex
+
+          VALID_MODES = %w[active idle dream maintenance].freeze
+
+          def transition(**opts)
+            target_mode = opts[:mode] || opts['mode']
+            return unless target_mode
+            return unless valid_mode?(target_mode)
+
+            force = opts[:force] || opts['force'] || false
+            current_mode = fetch_current_mode
+            return if current_mode == target_mode.to_s
+
+            return if !force && critical_tasks_running?
+
+            execute_transition(from: current_mode, to: target_mode.to_s)
+          end
+
+          def valid_mode?(mode)
+            VALID_MODES.include?(mode.to_s)
+          end
+
+          def critical_tasks_running?
+            count = Legion::Cache.get('scheduler_critical_task_count')
+            count.is_a?(Integer) ? count.positive? : false
+          end
+
+          def fetch_current_mode
+            Legion::Cache.get('scheduler_operating_mode') || 'active'
+          end
+
+          def execute_transition(from:, to:)
+            Legion::Cache.set('scheduler_operating_mode', to, 3600)
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Summary

Automated fix for #2, generated by the GitHub Swarm pipeline.

## Approach

Create the three missing runner modules (mode_scheduler.rb, mode_transition.rb, emergency_promotion.rb) following the exact same module/include pattern as the existing schedule.rb runner, with behavior matching the CHANGELOG v0.2.0 descriptions.

## Pipeline Details

- **Attempt:** 1
- **Fixer model:** `us.anthropic.claude-sonnet-4-6`
- **Generated at:** 2026-03-29T06:33:52Z

## Token Usage

| Call | Model | Input | Output | Thinking | Max Tokens |
|------|-------|-------|--------|----------|------------|
| 1 | `us.anthropic.claude-sonnet-4-6` | 20681 | 2982 | 1898/8000 | 2982/32000 |
| 2 | `us.anthropic.claude-sonnet-4-6` | 2384 | 1190 | - | 1190/128000 |
| **Total** | | **23065** | **4172** | | |

## Review Checklist

- [ ] Changes are correct and fix the issue
- [ ] No unintended side effects
- [ ] Tests pass (if applicable)
- [ ] Code style is consistent with the repository

---

> This PR was generated by the UHG Grid GitHub Swarm.
> The swarm never merges. Final approval and merge is your responsibility.
> Closes #2
